### PR TITLE
Feat/verify phone and resend code capability

### DIFF
--- a/src/client/app/assets/style/_button.scss
+++ b/src/client/app/assets/style/_button.scss
@@ -16,3 +16,19 @@
 .button-white {
   color: $white-color;
 }
+
+.button-plain {
+  border: none;
+  background: none;
+
+  &.underline {
+    text-decoration: underline;
+  }
+}
+
+.button-back {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}

--- a/src/client/app/assets/style/_color.scss
+++ b/src/client/app/assets/style/_color.scss
@@ -9,7 +9,7 @@ $accent-color: #79d8cc;
 $accent-light-color: #88f2e6;
 $accent-dark-color: #6cbfb5;
 
-//background colors
+// background colors
 $pink-color: #ede0df;
 
 // grey colors
@@ -26,5 +26,8 @@ $brown-light-color: #ab9491;
 
 // icon colors
 $red-color: #dc3444;
+
+// notification colors
+$notice-error-color: #de4242;
 
 $white-color: #f6f6f6;

--- a/src/client/app/assets/style/index.scss
+++ b/src/client/app/assets/style/index.scss
@@ -21,6 +21,7 @@
 @import 'routes/all-services';
 @import 'routes/contact';
 @import 'routes/error';
+@import 'routes/login';
 @import 'routes/manage';
 @import 'routes/service';
 

--- a/src/client/app/assets/style/routes/_login.scss
+++ b/src/client/app/assets/style/routes/_login.scss
@@ -1,0 +1,53 @@
+.login-form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  width: 40%;
+  height: 100vh;
+  margin: 0 auto;
+
+  .form {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 10px;
+    position: relative;
+    top: 20%;
+    background-color: $white-color;
+    padding: 40px;
+    border-radius: 5px;
+  }
+
+  .form-title {
+    font-size: 24px;
+    text-align: center;
+  }
+
+  .form-subtitle {
+    text-align: center;
+    margin-bottom: 20px;
+  }
+}
+
+.resend-button-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: 30px;
+}
+
+.error-message {
+  color: $notice-error-color;
+  margin-bottom: 15px;
+}
+
+.error-input {
+  border: $notice-error-color 1px solid;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/src/client/app/routes/login.tsx
+++ b/src/client/app/routes/login.tsx
@@ -1,7 +1,16 @@
-import { useState, type ChangeEvent, type FormEvent, useContext } from 'react';
+import {
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+  useContext,
+  useEffect,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
+import Button from 'react-bootstrap/Button';
 import axios from 'axios';
+import { ArrowBackOutline } from '@styled-icons/evaicons-outline';
 import { AuthContext } from '../store/auth-context';
+import { isValidPhone } from '../util/phone-helper';
 
 const BASE_URL = import.meta.env.VITE_BASE_API_URL || 'http://localhost:5000';
 
@@ -13,34 +22,65 @@ const Login = () => {
   const [phoneInput, setPhoneInput] = useState('');
   const [codeInput, setCodeInput] = useState('');
   const [hasPhone, setHasPhone] = useState(false);
+  const [isResendDisabled, setIsResendDisabled] = useState(false);
+  const [timer, setTimer] = useState(30);
+  const [codeError, setCodeError] = useState('');
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | undefined;
+
+    if (isResendDisabled) {
+      interval = setInterval(() => {
+        setTimer((prevTimer) => {
+          if (prevTimer === 0) {
+            clearInterval(interval);
+            setIsResendDisabled(false);
+            return 30;
+          }
+          return prevTimer - 1;
+        });
+      }, 1000);
+    }
+
+    if (!isResendDisabled) {
+      return clearInterval(interval);
+    }
+  }, [isResendDisabled]);
 
   const sendCode = async () => {
-    try {
-      await axios.get(`${BASE_URL}/sendCode?phone=${phoneInput}`);
-    } catch (e) {
-      console.log(e);
-      throw new Error('Send code failed');
+    if (phoneInput) {
+      try {
+        await axios.get(`${BASE_URL}/sendCode?phone=${phoneInput}`);
+      } catch (e) {
+        throw new Error('Send code failed');
+      }
     }
   };
 
   const verifyCode = async () => {
-    try {
-      const response = await axios.get(
-        `${BASE_URL}/verifyCode?phone=${phoneInput}&code=${codeInput}`
-      );
-      if (response.status === 200) {
-        setIsAuthenticated(true);
-        navigate('/manage');
+    if (codeInput) {
+      try {
+        const response = await axios.get(
+          `${BASE_URL}/verifyCode?phone=${phoneInput}&code=${codeInput}`
+        );
+        if (response.status === 200) {
+          setIsAuthenticated(true);
+          navigate('/manage');
+        }
+      } catch (e) {
+        setCodeError('Invalid code');
+        throw new Error('Verify code failed');
       }
-      console.log(response);
-    } catch (e) {
-      console.log(e);
-      throw new Error('Verify code failed');
     }
   };
 
   const phoneChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
     setPhoneInput(e.target.value);
+    if (e.target.value.length !== 8) {
+      setCodeError('Phone number must be 8 digits long');
+    } else {
+      setCodeError('');
+    }
   };
 
   const codeChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
@@ -49,8 +89,14 @@ const Login = () => {
 
   const onSubmitPhone = (e: FormEvent) => {
     e.preventDefault();
-    sendCode();
-    setHasPhone(true);
+    if (phoneInput.length !== 8 && !isValidPhone(phoneInput)) {
+      setCodeError('Phone number must be 8 digits long');
+    } else {
+      setCodeError('');
+      setHasPhone(true);
+      sendCode();
+      setIsResendDisabled(true);
+    }
   };
 
   const onSubmitCode = (e: FormEvent) => {
@@ -58,34 +104,83 @@ const Login = () => {
     verifyCode();
   };
 
+  const onResendCode = () => {
+    setIsResendDisabled(true);
+    setTimer(30);
+    sendCode();
+  };
+
+  const backHandler = () => {
+    setPhoneInput('');
+    setCodeInput('');
+    setCodeError('');
+    setHasPhone(false);
+    setIsResendDisabled(false);
+  };
+
   return (
     <div>
       {hasPhone ? (
-        <form onSubmit={onSubmitCode}>
-          <label htmlFor='code'>Please enter the OTP</label>
-          <input
-            type='number'
-            id='code'
-            name='code'
-            value={codeInput}
-            onChange={codeChangeHandler}
-          ></input>
-          <button type='submit'>Submit</button>
-        </form>
+        <div className='login-form-container'>
+          <form onSubmit={onSubmitCode} className='form' noValidate>
+            <button className='button-plain button-back' onClick={backHandler}>
+              <ArrowBackOutline size='24' />
+              Back
+            </button>
+
+            <div className='form-title'>Confirm your phone number</div>
+            <div className='form-subtitle'>
+              {`We just sent a code to +65 ${phoneInput}, enter it below`}
+            </div>
+            <label htmlFor='code'>Code</label>
+            <input
+              type='number'
+              id='code'
+              name='code'
+              required
+              value={codeInput}
+              onChange={codeChangeHandler}
+              className={codeError ? 'error-input' : ''}
+            />
+            {codeError && <div className='error-message'>{codeError}</div>}
+            <Button type='submit'>Verify now</Button>
+            <div className='resend-button-container'>
+              {isResendDisabled &&
+                `Did not receive the code? Retry in ${timer} seconds`}
+              <button
+                disabled={isResendDisabled}
+                className='button-plain underline'
+                onClick={onResendCode}
+              >
+                Resend code
+              </button>
+            </div>
+          </form>
+        </div>
       ) : (
-        <form onSubmit={onSubmitPhone}>
-          <label htmlFor='phone'>Please enter your phone number</label>
-          <input
-            type='tel'
-            id='phone'
-            name='phone'
-            pattern='[0-9]{8}'
-            maxLength={8}
-            value={phoneInput}
-            onChange={phoneChangeHandler}
-          ></input>
-          <button type='submit'>Submit</button>
-        </form>
+        <div className='login-form-container'>
+          <form onSubmit={onSubmitPhone} className='form' noValidate>
+            <div className='form-title'>Verify you are real</div>
+            <div className='form-subtitle'>
+              Enter your phone number to receive a SMS verification code.
+            </div>
+            <label htmlFor='phone'>Phone Number</label>
+            <input
+              type='tel'
+              id='phone'
+              name='phone'
+              required
+              pattern='[0-9]{8}'
+              minLength={8}
+              maxLength={8}
+              value={phoneInput}
+              onChange={phoneChangeHandler}
+              className={codeError ? 'error-input' : ''}
+            />
+            {codeError && <div className='error-message'>{codeError}</div>}
+            <Button type='submit'>Send code</Button>
+          </form>
+        </div>
       )}
     </div>
   );

--- a/src/client/app/test/__tests__/phone-helper.test.ts
+++ b/src/client/app/test/__tests__/phone-helper.test.ts
@@ -1,0 +1,27 @@
+import { isValidPhone } from '../../util/phone-helper';
+
+describe('isValidPhone', () => {
+  it('should return true if phone number is a string with 8 digits', () => {
+    const mockValidNumber = '12345678';
+
+    expect(isValidPhone(mockValidNumber)).toBe(true);
+  });
+
+  it('should return false if phone number is a string containing 8 characters other than digits', () => {
+    const mockInvalidNumber = '123abc45';
+
+    expect(isValidPhone(mockInvalidNumber)).toBe(false);
+  });
+
+  it('should return false if phone number is a string with less than 8 digits', () => {
+    const mockInvalidNumber = '1234567';
+
+    expect(isValidPhone(mockInvalidNumber)).toBe(false);
+  });
+
+  it('should return false if phone number is a string with more than 8 digits', () => {
+    const mockInvalidNumber = '123456789';
+
+    expect(isValidPhone(mockInvalidNumber)).toBe(false);
+  });
+});

--- a/src/client/app/util/phone-helper.ts
+++ b/src/client/app/util/phone-helper.ts
@@ -1,0 +1,6 @@
+const isValidPhone = (phone: string) => {
+  const regex = /^[0-9]{8}$/;
+  return regex.test(phone);
+};
+
+export { isValidPhone };


### PR DESCRIPTION
**What:** update login component to enable more verification checks

**How:**
- created `phone-helper` to verify if phone input is 8 digits only
- added capability to resend code after 30 seconds

**Screenshots:**

error message if invalid phone input
<img width="1341" alt="Screenshot 2024-01-04 at 6 39 28 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/de051cf3-948a-466e-b28e-c18050fa6440">

added resend code capability, button disabled if 30 seconds has yet to lapsed
<img width="1587" alt="Screenshot 2024-01-04 at 6 51 49 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/b08dd3f4-745c-42ab-9299-4017a0c262ad">

resend button enabled after 30 seconds
<img width="1596" alt="Screenshot 2024-01-04 at 6 52 26 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/c353ebfc-9d19-4509-85d2-faff4d6fc0db">


error message if invalid code
<img width="1590" alt="Screenshot 2024-01-04 at 6 52 38 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/f1d6e483-9e7e-462c-97dd-34de75cd3275">

api requests working for both `sendCode` and `verifyCode`
<img width="1186" alt="Screenshot 2024-01-04 at 7 06 53 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/f4dd60d3-d75e-4fa9-8e5b-6e3637a357a9">


**Test:**

<img width="671" alt="Screenshot 2024-01-04 at 7 10 30 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/2ea9dead-a774-453d-9b64-ca3504480033">
