### PR TITLE
Feat/search bar for categories and services

### DIFF
--- a/src/client/app/assets/style/_search.scss
+++ b/src/client/app/assets/style/_search.scss
@@ -1,0 +1,7 @@
+.search-input {
+  width: 30%;
+  height: 35px;
+  padding: 10px;
+  border-radius: 5px;
+  border: none;
+}

--- a/src/client/app/assets/style/_tabs.scss
+++ b/src/client/app/assets/style/_tabs.scss
@@ -1,3 +1,11 @@
+.tabs-content-container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  border-top: #bdbdbd 1.5px solid;
+  padding-top: 20px;
+}
+
 .tab-grid-container {
   display: flex;
   flex-wrap: wrap;

--- a/src/client/app/assets/style/index.scss
+++ b/src/client/app/assets/style/index.scss
@@ -13,6 +13,7 @@
 @import 'map';
 @import 'modal';
 @import 'navbar';
+@import 'search';
 @import 'separator';
 @import 'spinner';
 @import 'tabs';

--- a/src/client/app/components/search/index.tsx
+++ b/src/client/app/components/search/index.tsx
@@ -1,0 +1,25 @@
+import { type ChangeEvent } from 'react';
+import { type SearchBarProps } from '../../types/search';
+
+const SearchBar = ({ searchInput, setSearchInput }: SearchBarProps) => {
+  const onChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchInput(e.currentTarget.value);
+  };
+
+  const onBlurHandler = () => {
+    setSearchInput('');
+  };
+
+  return (
+    <input
+      type='search'
+      value={searchInput}
+      placeholder='Start typing to search'
+      className='search-input'
+      onChange={onChangeHandler}
+      onBlur={onBlurHandler}
+    />
+  );
+};
+
+export default SearchBar;

--- a/src/client/app/components/search/index.tsx
+++ b/src/client/app/components/search/index.tsx
@@ -13,6 +13,7 @@ const SearchBar = ({ searchInput, setSearchInput }: SearchBarProps) => {
   return (
     <input
       type='search'
+      role='searchField'
       value={searchInput}
       placeholder='Start typing to search'
       className='search-input'

--- a/src/client/app/components/tabs/helpers.tsx
+++ b/src/client/app/components/tabs/helpers.tsx
@@ -1,6 +1,6 @@
 import Button from 'react-bootstrap/Button';
 import { type CardServiceFormInputProps } from '../../types/form.ts';
-import { type CardCategoryObjectProps } from '../../types/card/card-category.ts';
+import { type CardCategoryProps } from '../../types/card/card-category.ts';
 import {
   type onDeleteCategoryHandlerProps,
   type onEditHandlerCategoeyProps,
@@ -55,21 +55,24 @@ const displayServices = (
 };
 
 const displayCategories = (
-  data: CardCategoryObjectProps,
+  data: CardCategoryProps[],
   deleteCategory: onDeleteCategoryHandlerProps,
   editCategory: onEditHandlerCategoeyProps
 ) => {
   return (
     <div className='tab-grid-container'>
-      {Object.entries(data).map(([key, value]) => {
-        const { id, image } = value;
+      {data.map((category) => {
+        const { id, name, image } = category;
         return (
           <div key={id} role='listCategories' className='list-item-container'>
             <div className='item-image-container'>
-              <div className='item-title'>{key.toUpperCase()}</div>
+              <div className='item-title'>{name.toUpperCase()}</div>
               <img src={image} alt='category name' className='item-image' />
               <div className='buttons-container-fixed'>
-                <Button variant='secondary' onClick={() => editCategory(value)}>
+                <Button
+                  variant='secondary'
+                  onClick={() => editCategory(category)}
+                >
                   Edit
                 </Button>
                 <Button variant='danger' onClick={() => deleteCategory(id)}>

--- a/src/client/app/components/tabs/index.tsx
+++ b/src/client/app/components/tabs/index.tsx
@@ -23,17 +23,23 @@ const TabSwitch = ({
   const [searchInput, setSearchInput] = useState('');
 
   const filterCategoryData = () => {
-    const filteredCategories = Object.values(categories).filter((category) =>
-      category.name.toLowerCase().includes(searchInput.toLocaleLowerCase())
-    );
-    return filteredCategories;
+    if (categories) {
+      const filteredCategories = Object.values(categories).filter((category) =>
+        category.name.toLowerCase().includes(searchInput.toLocaleLowerCase())
+      );
+      return filteredCategories;
+    }
+    return [];
   };
 
   const filterServiceData = (services: CardServiceFormInputProps[]) => {
-    const filteredServices = services.filter((service) =>
-      service.name.toLowerCase().includes(searchInput.toLowerCase())
-    );
-    return filteredServices;
+    if (services) {
+      const filteredServices = services.filter((service) =>
+        service.name.toLowerCase().includes(searchInput.toLowerCase())
+      );
+      return filteredServices;
+    }
+    return [];
   };
 
   const tabOptions = () => {

--- a/src/client/app/components/tabs/index.tsx
+++ b/src/client/app/components/tabs/index.tsx
@@ -1,13 +1,15 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import Tab from 'react-bootstrap/Tab';
 import Col from 'react-bootstrap/Col';
 import Nav from 'react-bootstrap/Nav';
 import Row from 'react-bootstrap/Row';
 import { type CardCategoryProps } from '../../types/card/card-category.ts';
+import { type CardServiceFormInputProps } from '../../types/form.ts';
 import { type TabsSwitchProps } from '../../types/tabs.ts';
 import { displayCategories, displayServices } from './helpers.tsx';
 import { CategoriesContext } from '../../store/categories-context.tsx';
 import { ServicesContext } from '../../store/services-context.tsx';
+import SearchBar from '../search/index.tsx';
 
 const TabSwitch = ({
   deleteCategory,
@@ -17,6 +19,22 @@ const TabSwitch = ({
 }: TabsSwitchProps) => {
   const { categories } = useContext(CategoriesContext);
   const { services } = useContext(ServicesContext);
+
+  const [searchInput, setSearchInput] = useState('');
+
+  const filterCategoryData = () => {
+    const filteredCategories = Object.values(categories).filter((category) =>
+      category.name.toLowerCase().includes(searchInput.toLocaleLowerCase())
+    );
+    return filteredCategories;
+  };
+
+  const filterServiceData = (services: CardServiceFormInputProps[]) => {
+    const filteredServices = services.filter((service) =>
+      service.name.toLowerCase().includes(searchInput.toLowerCase())
+    );
+    return filteredServices;
+  };
 
   const tabOptions = () => {
     return Object.values(categories).map(
@@ -32,14 +50,18 @@ const TabSwitch = ({
     );
   };
 
-  const tabContent = () => {
+  const tabServiceContent = () => {
     return Object.values(categories).map(
       (category: CardCategoryProps, index) => {
         const selectedService = services[category.name];
 
         return (
           <Tab.Pane eventKey={`${category.name}`} key={index}>
-            {displayServices(selectedService, deleteService, editService)}
+            {displayServices(
+              filterServiceData(selectedService),
+              deleteService,
+              editService
+            )}
           </Tab.Pane>
         );
       }
@@ -47,26 +69,33 @@ const TabSwitch = ({
   };
 
   return (
-    <Tab.Container defaultActiveKey='All'>
-      <Row>
-        <Col sm={2}>
-          <Nav variant='pills' className='flex-column'>
-            <Nav.Item>
-              <Nav.Link eventKey='All'>All</Nav.Link>
-            </Nav.Item>
-            {tabOptions()}
-          </Nav>
-        </Col>
-        <Col sm={10}>
-          <Tab.Content>
-            <Tab.Pane eventKey='All'>
-              {displayCategories(categories, deleteCategory, editCategory)}
-            </Tab.Pane>
-            {tabContent()}
-          </Tab.Content>
-        </Col>
-      </Row>
-    </Tab.Container>
+    <div className='tabs-content-container'>
+      <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
+      <Tab.Container defaultActiveKey='All'>
+        <Row>
+          <Col sm={2}>
+            <Nav variant='pills' className='flex-column'>
+              <Nav.Item>
+                <Nav.Link eventKey='All'>All</Nav.Link>
+              </Nav.Item>
+              {tabOptions()}
+            </Nav>
+          </Col>
+          <Col sm={10}>
+            <Tab.Content>
+              <Tab.Pane eventKey='All'>
+                {displayCategories(
+                  filterCategoryData(),
+                  deleteCategory,
+                  editCategory
+                )}
+              </Tab.Pane>
+              {tabServiceContent()}
+            </Tab.Content>
+          </Col>
+        </Row>
+      </Tab.Container>
+    </div>
   );
 };
 

--- a/src/client/app/test/__mocks__/details-mock.ts
+++ b/src/client/app/test/__mocks__/details-mock.ts
@@ -1,0 +1,12 @@
+export const detailsMock = [
+  {
+    index: 1,
+    duration: '10',
+    price: '10',
+  },
+  {
+    index: 2,
+    duration: '20',
+    price: '20',
+  },
+];

--- a/src/client/app/test/__mocks__/service-mock.ts
+++ b/src/client/app/test/__mocks__/service-mock.ts
@@ -1,0 +1,29 @@
+import { detailsMock } from './details-mock';
+
+export const servicesMock = {
+  'Mock category1 name': [
+    {
+      id: '123',
+      category: 'category 1.1',
+      name: 'service 1.1',
+      description: 'service description 1.1',
+      details: detailsMock,
+    },
+    {
+      id: '456',
+      category: 'category 1.2',
+      name: 'service 1.2',
+      description: 'service description 1.2',
+      details: detailsMock,
+    },
+  ],
+  'Mock category2 name': [
+    {
+      id: '789',
+      category: 'category 2.1',
+      name: 'service 2.1',
+      description: 'service description 2.1',
+      details: detailsMock,
+    },
+  ],
+};

--- a/src/client/app/test/__mocks__/tabs-mock.ts
+++ b/src/client/app/test/__mocks__/tabs-mock.ts
@@ -1,18 +1,18 @@
 import { type CardServiceFormInputProps } from '../../types/form.ts';
 import { cardDetailsArrayProps } from './card-mock.ts';
 
-export const categoryArrayProps = {
-  MockCategory1: {
+export const categoryArrayProps = [
+  {
     id: '123',
     name: 'Mock Title 1',
     image: 'mock-image-1',
   },
-  MockCategory2: {
+  {
     id: '456',
     name: 'Mock Title 2',
     image: 'mock-image-2',
   },
-};
+];
 
 export const serviceArrayProps: CardServiceFormInputProps[] = [
   {

--- a/src/client/app/test/__tests__/components/search.test.tsx
+++ b/src/client/app/test/__tests__/components/search.test.tsx
@@ -8,11 +8,11 @@ describe('SearchBar', () => {
   it('should update search input value when typing', () => {
     const updatedInput = 'updated value';
 
-    const { getByPlaceholderText } = render(
+    const { getByRole } = render(
       <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
     );
 
-    const searchField = getByPlaceholderText('Start typing to search');
+    const searchField = getByRole('searchField');
     fireEvent.change(searchField, { target: { value: updatedInput } });
 
     expect(setSearchInput).toHaveBeenCalledWith(updatedInput);
@@ -22,11 +22,11 @@ describe('SearchBar', () => {
     const searchInput = 'test';
     const setSearchInput = jest.fn();
 
-    const { getByPlaceholderText } = render(
+    const { getByRole } = render(
       <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
     );
 
-    const searchField = getByPlaceholderText('Start typing to search');
+    const searchField = getByRole('searchField');
     fireEvent.blur(searchField);
 
     expect(setSearchInput).toHaveBeenCalledWith('');

--- a/src/client/app/test/__tests__/components/search.test.tsx
+++ b/src/client/app/test/__tests__/components/search.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render } from '@testing-library/react';
+import SearchBar from '../../../components/search';
+
+describe('SearchBar', () => {
+  const searchInput = 'test';
+  const setSearchInput = jest.fn();
+
+  it('should update search input value when typing', () => {
+    const updatedInput = 'updated value';
+
+    const { getByPlaceholderText } = render(
+      <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
+    );
+
+    const searchField = getByPlaceholderText('Start typing to search');
+    fireEvent.change(searchField, { target: { value: updatedInput } });
+
+    expect(setSearchInput).toHaveBeenCalledWith(updatedInput);
+  });
+
+  it('should clear the search input when losing focus', () => {
+    const searchInput = 'test';
+    const setSearchInput = jest.fn();
+
+    const { getByPlaceholderText } = render(
+      <SearchBar searchInput={searchInput} setSearchInput={setSearchInput} />
+    );
+
+    const searchField = getByPlaceholderText('Start typing to search');
+    fireEvent.blur(searchField);
+
+    expect(setSearchInput).toHaveBeenCalledWith('');
+  });
+});

--- a/src/client/app/test/__tests__/components/tabs.test.tsx
+++ b/src/client/app/test/__tests__/components/tabs.test.tsx
@@ -29,7 +29,7 @@ describe('displayCategories', () => {
   });
 
   it('should render component with uppercase title', () => {
-    const title = screen.getByText('MOCKCATEGORY1');
+    const title = screen.getByText('MOCK TITLE 1');
 
     expect(title).toBeInTheDocument();
   });

--- a/src/client/app/test/__tests__/components/tabs/tabs-helper.test.tsx
+++ b/src/client/app/test/__tests__/components/tabs/tabs-helper.test.tsx
@@ -2,11 +2,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import {
   displayCategories,
   displayServices,
-} from '../../../components/tabs/helpers.tsx';
+} from '../../../../components/tabs/helpers.tsx';
 import {
   categoryArrayProps,
   serviceArrayProps,
-} from '../../__mocks__/tabs-mock.ts';
+} from '../../../__mocks__/tabs-mock.ts';
 
 describe('displayCategories', () => {
   const mockOnDeleteHandler = jest.fn();

--- a/src/client/app/test/__tests__/components/tabs/tabs.test.tsx
+++ b/src/client/app/test/__tests__/components/tabs/tabs.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import TabSwitch from '../../../../components/tabs';
+import { CategoriesContext } from '../../../../store/categories-context';
+import { ServicesContext } from '../../../../store/services-context';
+import { categoriesMock } from '../../../__mocks__/category-mock';
+import { servicesMock } from '../../../__mocks__/service-mock';
+
+const switchProps = {
+  deleteCategory: jest.fn(),
+  editCategory: jest.fn(),
+  deleteService: jest.fn(),
+  editService: jest.fn(),
+};
+
+describe('TabSwitch', () => {
+  beforeEach(() => {
+    render(
+      <CategoriesContext.Provider
+        value={{
+          categories: categoriesMock,
+          setCategories: jest.fn(),
+          addCategory: jest.fn(),
+          updateCategory: jest.fn(),
+          deleteCategory: jest.fn(),
+        }}
+      >
+        <ServicesContext.Provider
+          value={{
+            services: servicesMock,
+            setServices: jest.fn(),
+            addService: jest.fn(),
+            updateService: jest.fn(),
+            deleteService: jest.fn(),
+          }}
+        >
+          <TabSwitch {...switchProps} />
+        </ServicesContext.Provider>
+      </CategoriesContext.Provider>
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should render the component', () => {
+    const tabOptions = screen.getByRole('tablist');
+    const tabContent = screen.getByRole('tabpanel', { name: 'All' });
+
+    expect(tabOptions).toBeInTheDocument();
+    expect(tabContent).toBeInTheDocument();
+  });
+
+  it('should switch between tabs', () => {
+    const activeTab = screen.getByText('Mock category1 name');
+    const inactiveTab = screen.getByText('All');
+    fireEvent.click(activeTab);
+
+    expect(activeTab).toHaveClass('active');
+    expect(inactiveTab).not.toHaveClass('active');
+  });
+
+  describe('should display categories based on search input', () => {
+    it('should display all categories if search input field is empty', () => {
+      const searchInputField = screen.getByRole('searchField');
+
+      fireEvent.change(searchInputField, { target: { value: '' } });
+
+      expect(screen.getByText('MOCK CATEGORY1 NAME')).toBeInTheDocument();
+      expect(screen.getByText('MOCK CATEGORY2 NAME')).toBeInTheDocument();
+    });
+
+    it('should only display filtered categories based on search input', () => {
+      const searchInputField = screen.getByRole('searchField');
+
+      fireEvent.change(searchInputField, { target: { value: 'category1' } });
+
+      const activeCategory = screen.getByText('MOCK CATEGORY1 NAME');
+
+      expect(activeCategory).toBeInTheDocument();
+    });
+  });
+
+  describe('should display services based on search input', () => {
+    it('should display all services if search input field is empty', () => {
+      const searchInputField = screen.getByRole('searchField');
+      const activeTab = screen.getByText('Mock category1 name');
+
+      fireEvent.click(activeTab);
+      fireEvent.change(searchInputField, { target: { value: '' } });
+
+      expect(screen.getByText('SERVICE 1.1')).toBeInTheDocument();
+      expect(screen.getByText('SERVICE 1.2')).toBeInTheDocument();
+    });
+
+    it('should only display filtered services based on search input', () => {
+      const searchInputField = screen.getByRole('searchField');
+      const activeTab = screen.getByText('Mock category1 name');
+
+      fireEvent.click(activeTab);
+      fireEvent.change(searchInputField, { target: { value: '1.1' } });
+
+      const activeService = screen.getByText('SERVICE 1.1');
+
+      expect(activeService).toBeInTheDocument();
+    });
+  });
+});

--- a/src/client/app/types/search.ts
+++ b/src/client/app/types/search.ts
@@ -1,0 +1,6 @@
+import { Dispatch, type SetStateAction } from 'react';
+
+export type SearchBarProps = {
+  searchInput: string;
+  setSearchInput: Dispatch<SetStateAction<string>>;
+};


### PR DESCRIPTION
**What:** search bar component for searching through list of categories and services

**How:**
- created search bar component using `<input type='search'`
- filter through categories and services entries and display base on `name`
- clear search input on blur

**Screenshots:**

https://github.com/Huiling97/we.bloom/assets/71744836/c97644e8-92b9-440a-ae55-8804d1f1cd0e

**Test:**
<img width="453" alt="Screenshot 2024-01-06 at 4 42 39 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/edcbb12d-7536-434d-8c83-b2bcd1ac668a">


<img width="559" alt="Screenshot 2024-01-07 at 2 47 44 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/a780e0bf-d0ce-48ec-bd16-9513c206ff36">


<img width="549" alt="Screenshot 2024-01-07 at 2 48 48 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/b6738168-d86b-49eb-89fd-29d2a2ac78e2">

