### PR TITLE
save categories name in lowercase

### DIFF
--- a/src/client/app/components/card/card-category/form.tsx
+++ b/src/client/app/components/card/card-category/form.tsx
@@ -59,16 +59,18 @@ const CardCategoryForm = ({ catgeoryData }: CardCategoryFormProps) => {
   };
 
   useEffect(() => {
+    const standardizedName = formData?.name.toLowerCase();
+
     const data = {
       id: formData.id,
-      name: formData.name,
+      name: standardizedName,
       image: formData.image,
       description: formData.description,
     };
 
     if (formData.name && formData.description && formData.image) {
-      categoriesCtx.addCategory({ [formData.name]: data });
-      set(ref(database, 'categories/' + formData.name), data);
+      categoriesCtx.addCategory({ [standardizedName]: data });
+      set(ref(database, 'categories/' + standardizedName), data);
       setShowModal(false);
       setIsFormCompleted(false);
     }

--- a/src/client/app/components/tabs/index.tsx
+++ b/src/client/app/components/tabs/index.tsx
@@ -25,7 +25,7 @@ const TabSwitch = ({
   const filterCategoryData = () => {
     if (categories) {
       const filteredCategories = Object.values(categories).filter((category) =>
-        category.name.toLowerCase().includes(searchInput.toLocaleLowerCase())
+        category.name.toLowerCase().includes(searchInput.toLowerCase())
       );
       return filteredCategories;
     }


### PR DESCRIPTION
**What:** save categories name in lowercase for standardization as it will be used as the params

**How:**
- transform categories name to lowercase before sending it to firebase and saving it in the store

**Screenshots:**

category name successfully saved in lowercase as seen from route params


https://github.com/Huiling97/we.bloom/assets/71744836/5dc13508-dcc1-4ac3-8e99-e15c4ef60f33




