### PR TITLE
Chore/do not display categories with no services

### DIFF
--- a/src/client/app/assets/style/_tabs.scss
+++ b/src/client/app/assets/style/_tabs.scss
@@ -14,6 +14,18 @@
   margin-bottom: 20px;
 }
 
+.list-item-empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  height: 100px;
+  border: $grey-medium-light-color 1px solid;
+  border-radius: 5px;
+  margin: 50px 200px;
+  background-color: $secondary-light-color;
+}
+
 .list-item-container {
   display: flex;
   flex-direction: column;

--- a/src/client/app/components/card/card-category/form.tsx
+++ b/src/client/app/components/card/card-category/form.tsx
@@ -19,6 +19,7 @@ const CardCategoryForm = ({ catgeoryData }: CardCategoryFormProps) => {
     name: isEditModal ? catgeoryData.name : '',
     image: '',
     description: isEditModal ? catgeoryData.description : '',
+    servicesCount: 0,
   };
 
   const [formData, setFormData] = useState(formInput);
@@ -66,6 +67,7 @@ const CardCategoryForm = ({ catgeoryData }: CardCategoryFormProps) => {
       name: standardizedName,
       image: formData.image,
       description: formData.description,
+      servicesCount: formData.servicesCount,
     };
 
     if (formData.name && formData.description && formData.image) {

--- a/src/client/app/components/card/card-grid/index.tsx
+++ b/src/client/app/components/card/card-grid/index.tsx
@@ -1,10 +1,7 @@
 import { type ReactNode } from 'react';
 import { type CardServiceObjectProps } from '../../../types/card/card-service.ts';
 import { type CardServiceFormInputProps } from '../../../types/form.ts';
-import {
-  type CardCategoryProps,
-  type CardCategoryObjectProps,
-} from '../../../types/card/card-category.ts';
+import { type CardCategoryObjectProps } from '../../../types/card/card-category.ts';
 import CardCategory from '../card-category/index.tsx';
 import CardService from '../card-services/index.tsx';
 
@@ -37,15 +34,14 @@ const CardGrid = <T extends CardTypeProps>({
                 details={details}
               />
             );
+          } else {
+            const { id, image, servicesCount } = value;
+            if (servicesCount !== 0) {
+              return (
+                <CardCategory key={index} id={id} name={key} image={image} />
+              );
+            }
           }
-          return (
-            <CardCategory
-              key={index}
-              id={(value as CardCategoryProps).id}
-              name={key}
-              image={(value as CardCategoryProps).image}
-            />
-          );
         })}
       </div>
     </div>

--- a/src/client/app/components/card/card-services/form.tsx
+++ b/src/client/app/components/card/card-services/form.tsx
@@ -16,14 +16,15 @@ import Form from 'react-bootstrap/Form';
 import ServiceDetailsForm from './details/form.tsx';
 import { displayCategoryOptions } from './helpers.tsx';
 import { ModalContext } from '../../../store/modal-context.tsx';
+import { CategoriesContext } from '../../../store/categories-context.tsx';
 import { ServicesContext } from '../../../store/services-context.tsx';
 import { DetailsContext } from '../../../store/details-context.tsx';
-import { ref, set } from 'firebase/database';
+import { ref, set, update } from 'firebase/database';
 import { database } from '../../../../main.tsx';
 
 const CardServiceForm = ({
   formId,
-  categories,
+  categoryTypes,
   service,
 }: CardServiceFormProps) => {
   const {
@@ -33,6 +34,7 @@ const CardServiceForm = ({
     isFormCompleted,
     setIsFormCompleted,
   } = useContext(ModalContext);
+  const { categories } = useContext(CategoriesContext);
   const { services, setServices, updateService } = useContext(ServicesContext);
   const { details, setDetails, addDetails, deleteDetails } =
     useContext(DetailsContext);
@@ -232,7 +234,14 @@ const CardServiceForm = ({
         } else {
           updatedData = [data];
         }
+
+        const updateServicesCount =
+          categories[dropdownOption].servicesCount! + 1;
+
         set(ref(database, 'services/' + dropdownOption), updatedData);
+        update(ref(database, 'categories/' + dropdownOption), {
+          servicesCount: updateServicesCount,
+        });
         closeModal();
       }
     }
@@ -252,7 +261,7 @@ const CardServiceForm = ({
             <option value='' disabled={true}>
               Open this select menu
             </option>
-            {displayCategoryOptions(categories)}
+            {displayCategoryOptions(categoryTypes)}
           </Form.Select>
           <Form.Control.Feedback type='invalid'>
             Please select a category

--- a/src/client/app/components/modal/form-modal.tsx
+++ b/src/client/app/components/modal/form-modal.tsx
@@ -12,7 +12,7 @@ const ShowModal: FunctionComponent<ShowModalProps> = ({
   formId,
   show,
   catgeoryData,
-  categories,
+  categoryTypes,
   service,
 }: ShowModalProps) => {
   const { setShowModal, setIsEditModal, setIsAuthModal } =
@@ -40,7 +40,7 @@ const ShowModal: FunctionComponent<ShowModalProps> = ({
         <Modal.Body>
           <FormComponent
             formId={formId as string}
-            categories={categories as string[]}
+            categoryTypes={categoryTypes as string[]}
             service={service as CardServiceFormInputProps}
             catgeoryData={catgeoryData as CardCategoryProps}
           />

--- a/src/client/app/components/tabs/helpers.tsx
+++ b/src/client/app/components/tabs/helpers.tsx
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash';
 import Button from 'react-bootstrap/Button';
 import { type CardServiceFormInputProps } from '../../types/form.ts';
 import { type CardCategoryProps } from '../../types/card/card-category.ts';
@@ -36,6 +37,15 @@ const displayServices = (
   deleteService: onDeleteServiceHandlerProps,
   editService: onEditServiceHandlerProps
 ) => {
+  if (isEmpty(services)) {
+    return (
+      <div className='list-item-empty'>
+        There are no services associated with this category yet.
+        <br />
+        Add some services now!
+      </div>
+    );
+  }
   return (
     <div className='tab-grid-container'>
       {services &&

--- a/src/client/app/routes/manage.tsx
+++ b/src/client/app/routes/manage.tsx
@@ -18,7 +18,7 @@ import { ServicesContext } from '../store/services-context.tsx';
 import { DetailsContext } from '../store/details-context.tsx';
 import { AuthContext } from '../store/auth-context.tsx';
 import { v4 as uuidv4 } from 'uuid';
-import { ref, set } from 'firebase/database';
+import { ref, set, update } from 'firebase/database';
 import { database } from '../../main.tsx';
 
 const Manage = () => {
@@ -51,6 +51,7 @@ const Manage = () => {
     id: '',
     name: '',
     image: '',
+    servicesCount: 0,
   });
   const [serviceData, setServiceDate] = useState<CardServiceFormInputProps>({
     id: '',
@@ -97,7 +98,13 @@ const Manage = () => {
         const remainingServices = categoryServices.filter(
           (service: CardServiceFormInputProps) => service.id !== id
         );
+
+        const updateServicesCount = categories[categoryKey].servicesCount! - 1;
+
         set(ref(database, 'services/' + categoryKey), remainingServices);
+        update(ref(database, 'categories/' + categoryKey), {
+          servicesCount: updateServicesCount,
+        });
       }
     }
   };
@@ -170,7 +177,7 @@ const Manage = () => {
                 form={CardServiceForm}
                 formId={formId}
                 show={showModal}
-                categories={categoryType}
+                categoryTypes={categoryType}
                 service={serviceData as CardServiceFormInputProps}
               />
             )}

--- a/src/client/app/test/__mocks__/modal-mock.tsx
+++ b/src/client/app/test/__mocks__/modal-mock.tsx
@@ -23,7 +23,7 @@ export const formModalProps: ShowModalProps = {
   form: MockFormComponent,
   show: false,
   catgeoryData: cardGenericProps,
-  categories: [],
+  categoryTypes: [],
   service: cardDetailedProps,
 };
 

--- a/src/client/app/types/card/card-category.ts
+++ b/src/client/app/types/card/card-category.ts
@@ -3,6 +3,7 @@ export interface CardCategoryProps {
   name: string;
   image: string;
   description?: string;
+  servicesCount?: number;
 }
 
 export interface CardCategoryObjectProps {

--- a/src/client/app/types/form.ts
+++ b/src/client/app/types/form.ts
@@ -4,7 +4,7 @@ import { type CardDetailsProps } from './card/card-service-details.ts';
 
 export type FormComponentProps = {
   formId: string;
-  categories: string[];
+  categoryTypes: string[];
   service: CardServiceFormInputProps;
   catgeoryData: CardCategoryProps;
 };
@@ -15,7 +15,7 @@ export type CardCategoryFormProps = {
 
 export type CardServiceFormProps = {
   formId: string;
-  categories: string[];
+  categoryTypes: string[];
   service: CardServiceFormInputProps;
 };
 

--- a/src/client/app/types/modal.ts
+++ b/src/client/app/types/modal.ts
@@ -9,7 +9,7 @@ export type ShowModalProps = {
   formId?: string;
   show: boolean;
   catgeoryData?: CardCategoryProps;
-  categories?: string[];
+  categoryTypes?: string[];
   service?: CardServiceFormInputProps;
 };
 


### PR DESCRIPTION
**What:** do not display categories with no associated services

**How:**
- added variable `servicesCount` under each category
- only display category if `servicesCount !== 0`
- update `servicesCount` on addition and deletion of services using `update` method from firebase
- display info text if there are no services under a category

**Screenshots:**

category displayed when a service is added under it

https://github.com/Huiling97/we.bloom/assets/71744836/7cce3014-215e-492e-b069-7ad8862bf993

category is not displayed when there is no service under it

https://github.com/Huiling97/we.bloom/assets/71744836/d9eec8aa-b7d2-4053-8346-da2764123527

info text is displayed if category has no associated services


https://github.com/Huiling97/we.bloom/assets/71744836/13bc6eb0-38a5-48b0-9c1f-b611f00e0bce



**Test:**

<img width="270" alt="Screenshot 2024-01-12 at 12 29 20 PM" src="https://github.com/Huiling97/we.bloom/assets/71744836/c3747f7c-e041-4061-9264-d05c577b4a89">


