### PR TITLE
Feat/display products categories tabs

### DIFF
--- a/src/client/app/assets/style/_card.scss
+++ b/src/client/app/assets/style/_card.scss
@@ -169,4 +169,5 @@
 // product card
 .card-product-container {
   margin: 0.5rem;
+  row-gap: 10px;
 }

--- a/src/client/app/components/card/card-product/helpers.ts
+++ b/src/client/app/components/card/card-product/helpers.ts
@@ -1,10 +1,17 @@
 import axios from 'axios';
 import URLConstants from '../../../util/constants/url-constants';
+import { useContext } from 'react';
+import { ProductsContext } from '../../../store/products-context';
 
 const fetchProducts = async () => {
+  const { setProducts } = useContext(ProductsContext);
+
   try {
     const response = await axios.get(`${URLConstants.PRODUCTS_PATH}/all`);
-    return response.data;
+    if (response.data) {
+      setProducts(response.data);
+      return response.data;
+    }
   } catch (e) {
     console.log('error', e);
     throw new Error('Unable to fetch products');

--- a/src/client/app/components/card/card-product/index.tsx
+++ b/src/client/app/components/card/card-product/index.tsx
@@ -1,25 +1,15 @@
-import { useEffect, useState } from 'react';
 import Card from 'react-bootstrap/Card';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
-import { fetchProducts } from './helpers';
-import { CardProductProps } from '../../../types/card/card-product';
+import {
+  type ProductProps,
+  type CardProductProps,
+} from '../../../types/card/card-product';
 
-const CardProduct = () => {
-  const [allProducts, setAllProducts] = useState<CardProductProps[]>([]);
-
-  useEffect(() => {
-    const getAllProducts = async () => {
-      const data = await fetchProducts();
-      setAllProducts(data);
-    };
-
-    getAllProducts();
-  }, []);
-
+const CardProduct = ({ products }: CardProductProps) => {
   return (
     <Row xs={1} md={4} className='card-product-container'>
-      {allProducts.map((product) => {
+      {products.map((product: ProductProps) => {
         return (
           <Col key={product.id}>
             <Card>

--- a/src/client/app/components/tabs/tab/index.tsx
+++ b/src/client/app/components/tabs/tab/index.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+import { TabsTopProps } from '../../../types/tabs';
+import CardProduct from '../../card/card-product';
+
+const TabsTop = ({ categories, products }: TabsTopProps) => {
+  const [key, setKey] = useState('all');
+
+  const displayCategoryContent = () =>
+    products.filter((product) => product.category === key);
+
+  const displayCategory = () =>
+    categories &&
+    Object.keys(categories).map((type) => {
+      return (
+        <Tab
+          key={`${type}`}
+          eventKey={`${type}`}
+          title={`${type.toUpperCase()}`}
+        >
+          <CardProduct products={displayCategoryContent()} />
+        </Tab>
+      );
+    });
+
+  return (
+    <Tabs activeKey={key} onSelect={(k) => setKey(k!)} className='mb-3'>
+      <Tab eventKey='all' title='All'>
+        <CardProduct products={products} />
+      </Tab>
+      {displayCategory()}
+    </Tabs>
+  );
+};
+
+export default TabsTop;

--- a/src/client/app/routes/shop.tsx
+++ b/src/client/app/routes/shop.tsx
@@ -1,7 +1,33 @@
-import CardProduct from '../components/card/card-product';
+import { useContext } from 'react';
+import { isEmpty } from 'lodash';
+import { CategoriesContext } from '../store/categories-context';
+import { ProductsContext } from '../store/products-context';
+import fetchCategoriesData from '../util/fetch-categories';
+import { fetchProducts } from '../components/card/card-product/helpers';
+import TabsTop from '../components/tabs/tab';
+import LoadingSpinner from '../components/spinner';
 
 const Shop = () => {
-  return <CardProduct />;
+  const { categories } = useContext(CategoriesContext);
+  const { products } = useContext(ProductsContext);
+
+  if (isEmpty(categories)) {
+    fetchCategoriesData();
+  }
+
+  if (isEmpty(products)) {
+    fetchProducts();
+  }
+
+  return (
+    <div>
+      {isEmpty(products) || isEmpty(categories) ? (
+        <LoadingSpinner />
+      ) : (
+        <TabsTop products={products} categories={categories} />
+      )}
+    </div>
+  );
 };
 
 export default Shop;

--- a/src/client/app/store/index.tsx
+++ b/src/client/app/store/index.tsx
@@ -4,6 +4,7 @@ import { ModalContextProvider } from './modal-context';
 import { CategoriesContextProvider } from './categories-context';
 import { DetailsContextProvider } from './details-context';
 import { ServicesContextProvider } from './services-context';
+import { ProductsContextProvider } from './products-context';
 
 const AllProviders: React.FC<AllProvidersProps> = ({ children }) => {
   return (
@@ -11,7 +12,9 @@ const AllProviders: React.FC<AllProvidersProps> = ({ children }) => {
       <ModalContextProvider>
         <CategoriesContextProvider>
           <ServicesContextProvider>
-            <DetailsContextProvider>{children}</DetailsContextProvider>
+            <DetailsContextProvider>
+              <ProductsContextProvider>{children}</ProductsContextProvider>
+            </DetailsContextProvider>
           </ServicesContextProvider>
         </CategoriesContextProvider>
       </ModalContextProvider>

--- a/src/client/app/store/products-context.tsx
+++ b/src/client/app/store/products-context.tsx
@@ -1,0 +1,44 @@
+import { ReactNode, createContext, useReducer } from 'react';
+import {
+  type ProductsContextProps,
+  type ProductsActionProps,
+} from '../types/context/products';
+import { type ProductProps } from '../types/card/card-product';
+
+const ProductsContext = createContext<ProductsContextProps>({
+  products: [],
+  setProducts: () => {},
+});
+
+const productsReducer = (
+  state: ProductProps[],
+  action: ProductsActionProps
+) => {
+  switch (action.type) {
+    case 'SET':
+      return [...action.payload];
+    default:
+      return state;
+  }
+};
+
+const ProductsContextProvider = ({ children }: { children: ReactNode }) => {
+  const [productsState, dispatch] = useReducer(productsReducer, []);
+
+  const setProducts = (productsData: ProductProps[]) => {
+    dispatch({ type: 'SET', payload: productsData });
+  };
+
+  const value = {
+    products: productsState,
+    setProducts: setProducts,
+  };
+
+  return (
+    <ProductsContext.Provider value={value}>
+      {children}
+    </ProductsContext.Provider>
+  );
+};
+
+export { ProductsContext, ProductsContextProvider };

--- a/src/client/app/types/card/card-product.ts
+++ b/src/client/app/types/card/card-product.ts
@@ -1,4 +1,4 @@
-export type CardProductProps = {
+export type ProductProps = {
   id: number;
   brand: string;
   category: string;
@@ -10,4 +10,8 @@ export type CardProductProps = {
   details: string;
   usage: string;
   ingredients: string;
+};
+
+export type CardProductProps = {
+  products: ProductProps[];
 };

--- a/src/client/app/types/context/products.ts
+++ b/src/client/app/types/context/products.ts
@@ -1,0 +1,15 @@
+import { ProductProps } from '../card/card-product';
+
+enum ProductsActionType {
+  SET = 'SET',
+}
+
+export interface ProductsContextProps {
+  products: ProductProps[];
+  setProducts: (productsData: ProductProps[]) => void;
+}
+
+export interface ProductsActionProps {
+  type: ProductsActionType | string;
+  payload: ProductProps[];
+}

--- a/src/client/app/types/tabs.ts
+++ b/src/client/app/types/tabs.ts
@@ -1,5 +1,9 @@
-import { type CardCategoryProps } from './card/card-category.ts';
+import {
+  type CardCategoryProps,
+  type CardCategoryObjectProps,
+} from './card/card-category.ts';
 import { type CardServiceFormInputProps } from './form.ts';
+import { type ProductProps } from './card/card-product.ts';
 
 export type onDeleteCategoryHandlerProps = (id: string) => void;
 export type onEditHandlerCategoeyProps = (value: CardCategoryProps) => void;
@@ -13,4 +17,9 @@ export type TabsSwitchProps = {
   editCategory: onEditHandlerCategoeyProps;
   deleteService: onDeleteServiceHandlerProps;
   editService: onEditServiceHandlerProps;
+};
+
+export type TabsTopProps = {
+  categories: CardCategoryObjectProps;
+  products: ProductProps[];
 };


### PR DESCRIPTION
**What:** add categories tab on `/shop` page

**How:**
- use react bootstrap tabs
- display categories using existing categories context
- set fetched products data using products context

**Screenshots:**

https://github.com/Huiling97/we.bloom/assets/71744836/01df275f-bf32-448f-9276-30f9d635a3b2

**Test:**

