### PR TITLE
Revert "added base path href"

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,9 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>we.bloom</title>
-    <base href="/" />
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/client/main.tsx"></script>
+    <script type="module" src="./src/client/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Reverts Huiling97/we.bloom#112

**What**: 

<img width="1665" alt="Screenshot 2024-03-04 at 9 10 04 AM" src="https://github.com/Huiling97/we.bloom/assets/71744836/ac8c8bbc-7dc4-4c50-8c69-b9188fbaa2c3">

**How**:
configured `rewrite` rules on render since this application is hosted on a static site and nested url are not captured by default
https://community.render.com/t/react-router-not-working-after-deploying-vite-react-project/11103